### PR TITLE
Update twin macro to point to tailwind config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "babelMacros": {
     "twin": {
-      "config": "src/tailwind.config.js",
+      "config": "./tailwind.config.js",
       "preset": "styled-components",
       "autoCssProp": true,
       "hasSuggestions": true


### PR DESCRIPTION
Changes the route of the twin macro to point to the `tailwind.config.js` in the root of the project.

Previously I had trouble extending the theme while using twin macro styled components. Updating this route solved this issue for me and allowed custom styles in the `tailwind.config.js` to be applied.